### PR TITLE
Unicode handling and checking of high precision Mapcodes

### DIFF
--- a/src/main/java/com/mapcode/Decoder.java
+++ b/src/main/java/com/mapcode/Decoder.java
@@ -16,10 +16,10 @@
 
 package com.mapcode;
 
+import javax.annotation.Nonnull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
 
 class Decoder {
     private static final Logger LOG = LoggerFactory.getLogger(Decoder.class);
@@ -29,7 +29,9 @@ class Decoder {
     // ----------------------------------------------------------------------
 
     @Nonnull
-    static Point decode(@Nonnull final String argMapcode, @Nonnull final Territory argTerritory) {
+    static Point decode(@Nonnull final String argMapcode,
+	    @Nonnull final Territory argTerritory)
+	    throws UnknownMapcodeException {
         LOG.trace("decode: mapcode={}, territory={}", argMapcode, argTerritory.name());
 
         String mapcode = argMapcode;
@@ -41,7 +43,10 @@ class Decoder {
 
         final int minpos = mapcode.indexOf('-');
         if (minpos > 0) {
-            extrapostfix = mapcode.substring(minpos + 1).trim();
+	    extrapostfix = decodeUTF16(mapcode.substring(minpos + 1).trim());
+	    if (extrapostfix.contains("Z")) {
+		throw new UnknownMapcodeException("Invalid character Z");
+	    }
             mapcode = mapcode.substring(0, minpos);
         }
 

--- a/src/test/java/com/mapcode/DecoderTest.java
+++ b/src/test/java/com/mapcode/DecoderTest.java
@@ -16,11 +16,11 @@
 
 package com.mapcode;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings({"OverlyBroadThrowsClause", "ProhibitedExceptionDeclared"})
 public class DecoderTest {
@@ -58,52 +58,71 @@ public class DecoderTest {
         assertEquals("decodeTomTomOffice hi-precision longitude", 4908540, point.getLonMicroDeg());
     }
 
-	@Test
-	public void unicodeMapcodeAthensAcropolis1() throws Exception {
-		LOG.info("unicodeMapcodeAthensAcropolis1");
-		final Point point = MapcodeCodec.decode("ΗΠ.Θ2", Territory.GRC);
-		assertEquals("decodeUnicode latitude", 37971812, point.getLatMicroDeg());
-		assertEquals("decodeUnicode longitude", 23726247,
-				point.getLonMicroDeg());
-	}
+    @Test
+    public void highPrecisionUnicodeAthensAcropolis1() throws Exception {
+	LOG.info("highPrecisionUnicodeAthensAcropolis1");
+	final Point point = MapcodeCodec.decode("ΗΠ.Θ2-Φ2", Territory.GRC);
+	assertEquals("decodeUnicode latitude", 37971844, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 23726223,
+		point.getLonMicroDeg());
+    }
 
-	@Test
-	public void unicodeMapcodeAthensAcropolis2() throws Exception {
-		LOG.info("unicodeMapcodeAthensAcropolis2");
-		final Point point = MapcodeCodec.decode("GRC ΗΠ.Θ2");
-		assertEquals("decodeUnicode latitude", 37971812, point.getLatMicroDeg());
-		assertEquals("decodeUnicode longitude", 23726247,
-				point.getLonMicroDeg());
-	}
+    @Test
+    public void highPrecisionUnicodeAthensAcropolis2() throws Exception {
+	LOG.info("highPrecisionUnicodeAthensAcropolis2");
+	final Point point = MapcodeCodec.decode("GRC ΗΠ.Θ2-Φ2");
+	assertEquals("decodeUnicode latitude", 37971844, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 23726223,
+		point.getLonMicroDeg());
+    }
 
-	@Test
-	public void unicodeMapcodeTokyoTower1() throws Exception {
-		LOG.info("unicodeMapcodeTokyoTower1");
-		final Point point = MapcodeCodec.decode("\u30c1\u30ca.8\u30c1", Territory.JPN);
-		assertEquals("decodeUnicode latitude", 35658660, point.getLatMicroDeg());
-		assertEquals("decodeUnicode longitude", 139745394,
-				point.getLonMicroDeg());
-	}
+    @Test
+    public void unicodeMapcodeAthensAcropolis1() throws Exception {
+	LOG.info("unicodeMapcodeAthensAcropolis1");
+	final Point point = MapcodeCodec.decode("ΗΠ.Θ2", Territory.GRC);
+	assertEquals("decodeUnicode latitude", 37971812, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 23726247,
+		point.getLonMicroDeg());
+    }
 
-	@Test
-	public void unicodeMapcodeTokyoTower2() throws Exception {
-		LOG.info("unicodeMapcodeTokyoTower2");
-		final Point point = MapcodeCodec.decode("JPN \u30c1\u30ca.8\u30c1");
-		assertEquals("decodeUnicode latitude", 35658660, point.getLatMicroDeg());
-		assertEquals("decodeUnicode longitude", 139745394,
-				point.getLonMicroDeg());
-	}
+    @Test
+    public void unicodeMapcodeAthensAcropolis2() throws Exception {
+	LOG.info("unicodeMapcodeAthensAcropolis2");
+	final Point point = MapcodeCodec.decode("GRC ΗΠ.Θ2");
+	assertEquals("decodeUnicode latitude", 37971812, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 23726247,
+		point.getLonMicroDeg());
+    }
 
-	@Test
-	public void mapCodeWithZeroGroitzsch() throws Exception {
-		LOG.info("mapCodeWithZeroGroitzsch");
-		final Point point = MapcodeCodec.decode("HMVM.3Q0", Territory.DEU);
-		assertEquals("decodeUnicode latitude", 51154852, point.getLatMicroDeg());
-		assertEquals("decodeUnicode longitude", 12278574,
-				point.getLonMicroDeg());
-	}
+    @Test
+    public void unicodeMapcodeTokyoTower1() throws Exception {
+	LOG.info("unicodeMapcodeTokyoTower1");
+	final Point point = MapcodeCodec.decode("\u30c1\u30ca.8\u30c1",
+		Territory.JPN);
+	assertEquals("decodeUnicode latitude", 35658660, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 139745394,
+		point.getLonMicroDeg());
+    }
 
-	@Test(expected = UnknownMapcodeException.class)
+    @Test
+    public void unicodeMapcodeTokyoTower2() throws Exception {
+	LOG.info("unicodeMapcodeTokyoTower2");
+	final Point point = MapcodeCodec.decode("JPN \u30c1\u30ca.8\u30c1");
+	assertEquals("decodeUnicode latitude", 35658660, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 139745394,
+		point.getLonMicroDeg());
+    }
+
+    @Test
+    public void mapCodeWithZeroGroitzsch() throws Exception {
+	LOG.info("mapCodeWithZeroGroitzsch");
+	final Point point = MapcodeCodec.decode("HMVM.3Q0", Territory.DEU);
+	assertEquals("decodeUnicode latitude", 51154852, point.getLatMicroDeg());
+	assertEquals("decodeUnicode longitude", 12278574,
+		point.getLonMicroDeg());
+    }
+
+    @Test(expected = UnknownMapcodeException.class)
     public void invalidTerritory() throws Exception {
         LOG.info("invalidTerritory");
         MapcodeCodec.decode("NLD 49.4V", Territory.NLD);
@@ -137,6 +156,30 @@ public class DecoderTest {
     public void invalidDotLocation4() throws Exception {
         LOG.info("invalidDotLocation4");
         MapcodeCodec.decode("494.V494V", Territory.NLD);
+    }
+
+    @Test(expected = UnknownMapcodeException.class)
+    public void invalidHighPrecisionCharacter() throws Exception {
+	LOG.info("invalidHighPrecisionCharacter");
+	MapcodeCodec.decode("49.4V-Z", Territory.NLD);
+    }
+
+    @Test(expected = UnknownMapcodeException.class)
+    public void invalidHighPrecisionCharacter2() throws Exception {
+	LOG.info("invalidHighPrecisionCharacter2");
+	MapcodeCodec.decode("49.4V-HZ", Territory.NLD);
+    }
+
+    @Test(expected = UnknownMapcodeException.class)
+    public void invalidHighPrecisionCharacter3() throws Exception {
+	LOG.info("invalidHighPrecisionCharacter3");
+	MapcodeCodec.decode("ΗΠ.Θ2-Б", Territory.GRC);
+    }
+
+    @Test(expected = UnknownMapcodeException.class)
+    public void invalidHighPrecisionCharacter4() throws Exception {
+	LOG.info("invalidHighPrecisionCharacter4");
+	MapcodeCodec.decode("ΗΠ.Θ2-ББ", Territory.GRC);
     }
 
     @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
I added Unicode handling of high precision Mapcodes and also added check to throw an UnknownMapcodeException if the character Z or equivalent Unicode character is contained in the high precision part according to the Mapcode documenation
